### PR TITLE
Add reviews

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,4 +13,12 @@ module.exports = {
       domain: process.env.AUTH0_DOMAIN,
     },
   },
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.node = {
+        fs: 'empty',
+      };
+    }
+    return config;
+  },
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@codeday/topocons": "^1.5.0",
     "@emotion/core": "^10.1.1",
     "@emotion/styled": "^10.0.27",
+    "annotpdf": "^1.0.15",
     "babel-plugin-inline-import-graphql-ast": "^2.4.1",
     "email-validator": "^2.0.4",
     "emotion-theming": "^10.0.27",
@@ -24,9 +25,11 @@
     "next-auth": "^3.1.0",
     "next-seo": "^4.15.0",
     "node-fetch": "^2.6.1",
+    "pdfjs-dist": "^2.16.105",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react-dom": "^17.0.1",
+    "react-pdf": "^5.7.2"
   },
   "devDependencies": {
     "@codeday/eslint-config": "^2.1.4",

--- a/public/annotation-note.svg
+++ b/public/annotation-note.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   width="40"
+   height="40"
+   viewBox="0 0 40 40">
+  <rect
+     width="36.075428"
+     height="31.096582"
+     x="1.962286"
+     y="4.4517088"
+     id="rect4"
+     style="fill:#ffff00;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.23004246;stroke-opacity:1" />
+  <rect
+     width="27.96859"
+     height="1.5012145"
+     x="6.0157046"
+     y="10.285"
+     id="rect6"
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+  <rect
+     width="27.96859"
+     height="0.85783684"
+     x="6.0157056"
+     y="23.21689"
+     id="rect8"
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+  <rect
+     width="27.96859"
+     height="0.85783684"
+     x="5.8130345"
+     y="28.964394"
+     id="rect10"
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+  <rect
+     width="27.96859"
+     height="0.85783684"
+     x="6.0157046"
+     y="17.426493"
+     id="rect12"
+     style="fill:#000000;fill-opacity:1;stroke:none" />
+</svg>

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import * as Icon from '@codeday/topocons/Icon';
+import { useColorModeValue } from '@codeday/topo/Theme';
+import Badge from './Badge';
+
+export default function Alert({ children, ...props }) {
+  return (
+    <Badge
+      bg={useColorModeValue('red.200', 'darkred')}
+      color={useColorModeValue('darkred', 'red.200')}
+      borderColor={useColorModeValue('darkred', undefined)}
+      borderWidth={useColorModeValue(1, 0)}
+      {...props}
+    >
+      <Icon.UiError />{' '}{children}
+    </Badge>
+  );
+}
+
+export function InfoAlert({ children, ...props }) {
+  return (
+    <Badge
+      bg={useColorModeValue('gray.50', 'gray.800')}
+      color={useColorModeValue('gray.800', 'gray.50')}
+      borderColor={useColorModeValue('gray.800', undefined)}
+      borderWidth={useColorModeValue(1, 0)}
+
+      {...props}
+    >
+      <Icon.UiInfo />{' '}{children}
+    </Badge>
+  );
+}
+
+export function WarningAlert({ children, ...props }) {
+  return (
+    <Badge
+      bg={useColorModeValue('orange.50', 'orange.800')}
+      color={useColorModeValue('orange.800', 'orange.50')}
+      borderColor={useColorModeValue('orange.800', undefined)}
+      borderWidth={useColorModeValue(1, 0)}
+      {...props}
+    >
+      <Icon.UiWarning />{' '}{children}
+    </Badge>
+  );
+}
+
+export function GoodAlert({ children, ...props }) {
+  return (
+    <Badge
+      bg={useColorModeValue('green.50', 'green.800')}
+      color={useColorModeValue('green.800', 'green.50')}
+      borderColor={useColorModeValue('green.800', undefined)}
+      borderWidth={useColorModeValue(1, 0)}
+      {...props}
+    >
+      <Icon.UiOk />{' '}{children}
+    </Badge>
+  );
+}

--- a/src/components/Badge.js
+++ b/src/components/Badge.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import Box from '@codeday/topo/Atom/Box';
+import { useColorModeValue } from '@codeday/topo/Theme';
+
+export default function Badge({ children, ...props }) {
+  return (
+    <Box
+      d="inline-flex"
+      alignItems="center"
+      bg={useColorModeValue('gray.200', 'gray.800')}
+      color={useColorModeValue('gray.800', 'gray.200')}
+      p={1}
+      px={2}
+      m={1}
+      rounded={5}
+      {...props}
+    >
+      <b>{children}</b>
+    </Box>
+  );
+}

--- a/src/components/EditAnnotation.js
+++ b/src/components/EditAnnotation.js
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import Button from '@codeday/topo/Atom/Button';
+import {Textarea} from '@codeday/topo/Atom/Input';
+import Box from '@codeday/topo/Atom/Box';
+import PropTypes from 'prop-types';
+import { AnnotationFactory } from 'annotpdf';
+import {
+  UiEdit, UiOk, UiX, UiTrash,
+} from '@codeday/topocons/Icon';
+import InfoBox from './InfoBox';
+
+export default function EditAnnotation({
+  onUpdate, onDelete, annotation, idx, children, ...props
+}) {
+  const [tempContents, setTempContents] = useState(annotation.contents);
+  const [editing, setEditing] = useState(false);
+  const okButton = (
+    <Button
+      h={6}
+      onClick={() => {
+        onUpdate(tempContents);
+        setEditing(false);
+      }}
+    >
+      <UiOk />
+    </Button>
+  );
+  const trashButton = (
+    <Button
+      h={6}
+      onClick={() => {
+        setEditing(false);
+      }}
+    >
+      <UiX />
+    </Button>
+  );
+  const deleteButton = (
+    <Button
+      h={6}
+      onClick={() => {
+        onDelete(annotation.id);
+      }}
+    ><UiTrash />
+    </Button>
+  );
+  const editButton = (
+    <Button
+      h={6}
+      onClick={() => {
+        setEditing(true);
+        setTempContents(annotation.contents);
+      }}
+    >
+      <UiEdit />
+    </Button>
+  );
+  return (
+    <InfoBox buttons={editing ? <Box>{okButton} {trashButton}</Box> : <Box>{editButton} {deleteButton}</Box>} {...props} heading={`Feedback #${idx}`}>
+      {editing
+        ? <Textarea value={tempContents} onChange={(e) => { setTempContents(e.target.value); }} /> : annotation.contents}
+      {children}
+    </InfoBox>
+  );
+}

--- a/src/components/InfoBox.js
+++ b/src/components/InfoBox.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import Box, { Flex } from '@codeday/topo/Atom/Box';
+import { useColorModeValue } from '@codeday/topo/Theme';
+
+export default function InfoBox({
+  children, heading, headingSize, buttons, nested, ...props
+}) {
+  return (
+    <Box
+      d="block"
+      borderWidth={3}
+      rounded={nested ? 1 : 3}
+      borderColor={useColorModeValue(nested ? 'gray.100' : undefined, nested ? 'gray.1200' : undefined)}
+      m={nested ? 0 : 1}
+      {...props}
+    >
+      {heading && (
+        <Flex
+          backgroundColor={useColorModeValue(nested ? 'gray.100' : 'gray.200', nested ? 'gray.1000' : 'gray.1200')}
+          fontSize={headingSize}
+          justifyContent="space-between"
+          fontWeight="bold"
+          p={2}
+        >
+          <Box>{heading}</Box>
+          <Box>{buttons}</Box>
+        </Flex>
+      )}
+      <Box
+        mt={1}
+        rounded={5}
+        p={1}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/ResumeReview.js
+++ b/src/components/ResumeReview.js
@@ -1,0 +1,169 @@
+import React, {useState, useMemo} from 'react';
+import {AnnotationFactory} from "annotpdf";
+import {Document, Page, pdfjs} from 'react-pdf';
+import Box, {Grid} from '@codeday/topo/Atom/Box';
+import Skelly from '@codeday/topo/Atom/Skelly';
+import Spinner from '@codeday/topo/Atom/Spinner';
+import Text from '@codeday/topo/Atom/Text';
+import Button from '@codeday/topo/Atom/Button'
+import {Textarea} from '@chakra-ui/react'; // not exported in this version of topo
+import List, {Item as ListItem} from '@codeday/topo/Atom/List';
+
+import {useDisclosure} from '@codeday/topo/utils';
+import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
+import {UiCheck, UiX} from "@codeday/topocons/Icon"
+import Popover, {
+    PopoverTrigger,
+    PopoverContent,
+    PopoverHeader,
+    PopoverBody,
+    PopoverArrow,
+    PopoverCloseButton,
+} from "@codeday/topo/Atom/Popover";
+// import { PopoverFooter } from '@chakra-ui/react' // not exported in this version of topo
+import EditAnnotation from "./EditAnnotation";
+import ResumeReviewGuide from "./ResumeReviewGuide";
+import InfoBox from "./InfoBox";
+import {InfoAlert} from "./Alert";
+
+const MINIMUM_ANNOTATION_COUNT = 1
+
+pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`
+
+
+export default function ResumeReview({pdf, annotatedFile, setAnnotatedFile}) {
+    const [numPages, setNumPages] = useState(1)
+    const [pageHeight, setPageHeight] = useState(null) // will cause problems if pages have varying heights but i dont care
+    const [annotationProps, setAnnotationProps] = useState()
+    const [annotator, setAnnotator] = useState(null)
+    const [feedbackText, setFeedbackText] = useState('')
+    const [popoverX, setPopoverX] = useState()
+    const [popoverY, setPopoverY] = useState()
+    const {isOpen, onToggle, onClose} = useDisclosure({onClose: () => setFeedbackText('')})
+    if(annotator && !annotatedFile) {
+        setAnnotatedFile(annotator.write())
+    }
+    console.log(annotator?.annotations)
+    const document = useMemo(() => (
+        <Document
+            loading={<Skelly h={pageHeight * numPages} />}
+            file={{data: annotatedFile}}
+        >
+            { [...Array(numPages).keys()].map((_, idx) => {
+                return (
+                    <Page
+                        key={idx}
+                        loading={<Skelly h={pageHeight} />}
+                        pageNumber={idx+1}
+                        onClick={(e) => {
+                            //https://stackoverflow.com/a/48390126
+                            const rect = e.currentTarget.getBoundingClientRect()
+                            const offsetX = e.pageX - window.pageXOffset - rect.left
+                            const offsetY = e.pageY - window.pageYOffset - rect.bottom
+                            setPopoverX(e.pageX)
+                            setPopoverY(e.pageY)
+                            setAnnotationProps({
+                                page: idx,
+                                rect: [offsetX, -offsetY, offsetX + 10, -offsetY + 10],
+                            })
+                            onToggle()
+                        }}
+                    />
+                )
+            })
+            }
+        </Document>
+    ), [numPages, annotator, annotatedFile])
+    return (
+        <Box>
+            {/*Really dumb hack because for some reason pdf.worker.js doesn't properly handle popupDate the same way*/}
+            {/*pdf.js does, so it displays as {{date}}, {{time}} and I think that's really annoying */}
+            <style type="text/css">
+                {`.annotationLayer .popupDate {
+                    display: none;
+                }
+                .textAnnotation > img {
+                content:url('/annotation-note.svg')
+                }
+                `}
+            </style>
+            <Document
+                file={pdf}
+                loading={< Spinner />}
+                onLoadSuccess={async (file) => {
+                    setAnnotator(new AnnotationFactory(await file.getData()))
+                    setNumPages(file.numPages)
+                    setPageHeight((await file.getPage(1)).view[3])
+                }}/>
+            <ResumeReviewGuide />
+            <Grid templateColumns='repeat(2, 1fr)' gap={4}>
+                <Popover
+                    isOpen={isOpen}
+                    onClose={onClose}
+                    closeOnBlur={false}
+                >
+                    <PopoverTrigger>
+                        <Box position="absolute" left={popoverX} top={popoverY}/>
+                    </PopoverTrigger>
+                    <PopoverContent>
+                        <PopoverHeader>
+                            <Text bold>Compose Feedback</Text>
+                        </PopoverHeader>
+                        <PopoverArrow />
+                        <PopoverCloseButton />
+                        <PopoverBody>
+                            <Textarea value={feedbackText} onChange={(e) => setFeedbackText(e.target.value)}/>
+                            <Box textAlign="right">
+                                <Button mr={4} colorScheme="red" variant="ghost" onClick={onClose}>
+                                    <UiX />
+                                </Button>
+                                <Button colorScheme="green" variant="ghost" onClick={() => {
+                                    annotator.createTextAnnotation({
+                                        ...annotationProps,
+                                        contents: feedbackText,
+                                        author: '', // todo: make this work
+                                        open: true
+                                    })
+                                    setAnnotatedFile(annotator.write())
+                                    onClose()
+                                }}>
+                                    <UiCheck />
+                                </Button>
+                            </Box>
+                        </PopoverBody>
+                    </PopoverContent>
+                </Popover>
+                <Box  display="inline-block">
+                    {document}
+                </Box>
+                <List styleType="none">
+                    <InfoBox heading="Your Feedback">
+                        {annotator?.annotations.length > 0?
+                            annotator.annotations.map((annotation, idx) => (
+                                <ListItem><EditAnnotation
+                                    annotation={annotation}
+                                    idx={idx + 1} // only used for visuals
+                                    onUpdate={(newContents) => {
+                                        let tempAnnotator = annotator
+                                        tempAnnotator.annotations[idx].contents = newContents
+                                        setAnnotator(tempAnnotator)
+                                        setAnnotatedFile(annotator.write())
+                                    }}
+                                    onDelete={(annotationId) => {
+                                        annotator.deleteAnnotation(annotationId).then(() => setAnnotatedFile(annotator.write()))
+                                    }}
+                                /></ListItem>
+                            )) :
+                            <ListItem>
+                                <InfoAlert>
+                                    You haven't added any feedback yet, click anywhere on the document to start
+                                    writing!
+                                </InfoAlert>
+                            </ListItem>
+                        }
+                    </InfoBox>
+                </List>
+            </Grid>
+        </Box>
+    )
+}

--- a/src/components/ResumeReviewGuide.js
+++ b/src/components/ResumeReviewGuide.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Text from '@codeday/topo/Atom/Text';
+import InfoBox from './InfoBox';
+
+export default function ResumeReviewGuide() {
+  return (
+    <InfoBox heading="Tips and Tricks">
+      <Text> You should do things like this</Text>
+      <Text>And not things like this</Text>
+    </InfoBox>
+  );
+}

--- a/src/components/ResumeReviewGuide.js
+++ b/src/components/ResumeReviewGuide.js
@@ -4,9 +4,10 @@ import InfoBox from './InfoBox';
 
 export default function ResumeReviewGuide() {
   return (
-    <InfoBox heading="Tips and Tricks">
-      <Text> You should do things like this</Text>
-      <Text>And not things like this</Text>
+    <InfoBox heading="Instructions">
+      <Text>Click anywhere on the resume to add an annotation.</Text>
+      <Text>Please focus on content and <em>NOT formatting</em> (unless the formatting is particularly bad).</Text>
+      <Text>You will receive an intro email to the student, in case they have any follow-up questions.</Text>
     </InfoBox>
   );
 }

--- a/src/pages/respond/[token]/[requestId]/index.gql
+++ b/src/pages/respond/[token]/[requestId]/index.gql
@@ -1,4 +1,4 @@
-mutation RespondRequest($request: String!, $file: Upload, $response: AdvisorsResponse) {
+mutation RespondRequest($request: String!, $file: Upload, $response: AdvisorsJSONObject) {
   advisors {
     respondRequest(request: $request, file: $file, response: $response)
   }

--- a/src/pages/respond/[token]/[requestId]/index.gql
+++ b/src/pages/respond/[token]/[requestId]/index.gql
@@ -1,0 +1,17 @@
+mutation RespondRequest($request: String!, $file: Upload, $response: AdvisorsResponse) {
+  advisors {
+    respondRequest(request: $request, file: $file, response: $response)
+  }
+}
+
+query GetRequest ($request: String!) {
+  advisors {
+    getRequest(request: $request) {
+      givenName
+      familyName
+      email
+      type
+      resumeUrl
+    }
+  }
+}

--- a/src/pages/respond/[token]/[requestId]/index.js
+++ b/src/pages/respond/[token]/[requestId]/index.js
@@ -1,0 +1,101 @@
+import { print } from 'graphql';
+import React, { useState, useReducer, useRef } from 'react';
+import Content from '@codeday/topo/Molecule/Content';
+import Box, { Grid } from '@codeday/topo/Atom/Box';
+import Text, { Heading } from '@codeday/topo/Atom/Text';
+import Page from '../../../../components/Page';
+import Button from '@codeday/topo/Atom/Button';
+import { default as Textarea } from '@codeday/topo/Atom/Input/Textarea';
+import { useToasts, apiFetch } from '@codeday/topo/utils';
+import { GetRequest, RespondRequest } from './index.gql';
+
+const QUESTIONS = {
+  RESUME: [
+    'Any general feedback about this resume which you\'d like to share?',
+    'In the next 3 months, what could this student focus on to best strengthen their resume? (i.e. particular projects, classes, etc)',
+  ],
+  INTERVIEW: [
+    'Overall, what was your assessment of the practice interview?',
+    'What subjects should the student focus on to best improve their chances of being hired?',
+  ],
+}
+
+export default function ({ token, request, requestId }) {
+  const [isSubmitted, setSubmitted] = useState(false);
+  const [isLoading, setLoading] = useState(false);
+  const [response, updateResponse] = useReducer((_prev, [key, value]) => ({ ..._prev, [key]: value }), {});
+  const { success, error } = useToasts();
+
+  const valid = Object.values(response).filter(Boolean).length >= QUESTIONS[request.type].length;
+  const title = `${request.type[0]}${request.type.slice(1).toLowerCase()} feedback for ${request.givenName} ${request.familyName}`;
+
+  if (request.type === 'RESUME' && !request.resumeUrl) return (
+    <Page>
+      <Content>Error occurred: resume request had no resume. Please contact volunteer@codeday.org for help.</Content>
+    </Page>
+  );
+
+  if (isSubmitted) return (
+    <Page>
+      <Content>Thank you for submitting your feedback! We've shared it with the student.</Content>
+    </Page>
+  );
+
+  return (
+    <Page title={title}>
+      <Content mt={-8}>
+        <Heading as="h2" fontSize="4xl" mb={8}>{title}</Heading>
+        {request.resumeUrl && (
+          <></>
+        )}
+        {QUESTIONS[request.type].map((q) => (
+          <>
+            <Heading as="h4" fontSize="md">{q}</Heading>
+            <Textarea mb={4} onChange={(e) => updateResponse([q, e.target.value])} />
+          </>
+        ))}
+        <Box textAlign="center">
+          <Button
+            isLoading={isLoading}
+            isDisabled={!valid}
+            colorScheme="green"
+            size="lg"
+            onClick={async () => {
+              setLoading(true);
+              try {
+                await apiFetch(
+                  print(RespondRequest),
+                  { request: requestId, response /*, file */},
+                  { 'X-Advisors-Authorization': `Bearer ${token}` },
+                );
+                success('Feedback submitted.')
+              } catch (ex) {
+                error(ex.toString());
+              }
+              setLoading(false);
+            }}
+          >
+            {!valid ? 'Fill all fields to submit' : 'Submit'}
+          </Button>
+        </Box>
+      </Content>
+    </Page>
+  )
+}
+
+export async function getServerSideProps({ params: { token, requestId } }) {
+
+  const request = (await apiFetch(
+    print(GetRequest),
+    { request: requestId },
+    { 'X-Advisors-Authorization': `Bearer ${token}` },
+  )).advisors.getRequest;
+
+  return {
+    props: {
+      token,
+      request,
+      requestId,
+    },
+  };
+}

--- a/src/pages/submit.js
+++ b/src/pages/submit.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getSession, signIn } from 'next-auth/client'
+import { getSession, signIn } from 'next-auth/client';
 import Content from '@codeday/topo/Molecule/Content';
 import CognitoForm from '@codeday/topo/Molecule/CognitoForm';
 import Page from '../components/Page';
@@ -10,18 +10,18 @@ export default function Submit({ username }) {
     return <></>;
   }
 
-	return (
-		<Page slug="/submit" title="Submit New">
+  return (
+    <Page slug="/submit" title="Submit New">
       <Content mt={-8}>
         <CognitoForm formId="78" prefill={{ Username: username }} />
       </Content>
-		</Page>
-	)
+    </Page>
+  );
 }
 
 export async function getServerSideProps(context) {
   const session = await getSession(context);
-  if (!session) return {props: {}};
+  if (!session) return { props: {} };
   return {
     props: {
       username: session.user.name,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,6 +2600,11 @@
   dependencies:
     prop-types "^15.7.2"
 
+"@types/crypto-js@^4.0.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.1.tgz#602859584cecc91894eb23a4892f38cfa927890d"
+  integrity sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==
+
 "@types/hast@^2.0.0":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.1.tgz#b16872f2a6144c7025f296fb9636a667ebb79cd9"
@@ -2611,6 +2616,11 @@
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
+"@types/json-schema@^7.0.8":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -2628,6 +2638,11 @@
   version "4.14.171"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.171.tgz#f01b3a5fe3499e34b622c362a46a609fdb23573b"
   integrity sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==
+
+"@types/pako@^1.0.1":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-1.0.4.tgz#b4262aef92680a9331fcdb8420c69cf3dd98d3f3"
+  integrity sha512-Z+5bJSm28EXBSUJEgx29ioWeEEHUh6TiMkZHDhLwjc9wVFH+ressbkmX6waUZc5R3Gobn4Qu5llGxaoflZ+yhA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -2859,7 +2874,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -2876,6 +2891,16 @@ ally.js@1.4.1:
   dependencies:
     css.escape "^1.5.0"
     platform "1.3.3"
+
+annotpdf@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/annotpdf/-/annotpdf-1.0.15.tgz#64e251a9492d3f73f1621eaf924d97db11f7ae6d"
+  integrity sha512-uDR1M4UFb9jfO/EEmki7UznICdxIzYw6igBusGVubohsg09XQYu2/5PLJFM6L3iw3qztAneNlII6shg6v368gA==
+  dependencies:
+    "@types/crypto-js" "^4.0.1"
+    "@types/pako" "^1.0.1"
+    crypto-js "^4.0.0"
+    pako "^1.0.10"
 
 anser@1.4.9:
   version "1.4.9"
@@ -4268,6 +4293,11 @@ domhandler@^3.0.0, domhandler@^3.3.0:
   dependencies:
     domelementtype "^2.0.1"
 
+dommatrix@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/dommatrix/-/dommatrix-1.0.3.tgz#e7c18e8d6f3abdd1fef3dd4aa74c4d2e620a0525"
+  integrity sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww==
+
 domutils@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.1.0.tgz#7ade3201af43703fde154952e3a868eb4b635f16"
@@ -4880,6 +4910,14 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+file-loader@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
+  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -6136,6 +6174,11 @@ merge-class-names@^1.1.1:
   resolved "https://registry.yarnpkg.com/merge-class-names/-/merge-class-names-1.3.0.tgz#c4cdc1a981a81dd9afc27aa4287e912a337c5dee"
   integrity sha512-k0Qaj36VBpKgdc8c188LEZvo6v/zzry/FUufwopWbMSp6/knfVFU/KIB55/hJjeIpg18IH2WskXJCRnM/1BrdQ==
 
+merge-refs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/merge-refs/-/merge-refs-1.0.0.tgz#388348bce22e623782c6df9d3c4fc55888276120"
+  integrity sha512-WZ4S5wqD9FCR9hxkLgvcHJCBxzXzy3VVE6p8W2OzxRzB+hLRlcadGE2bW9xp2KSzk10rvp4y+pwwKO6JQVguMg==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -6763,7 +6806,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pako@~1.0.5:
+pako@^1.0.10, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -6916,6 +6959,19 @@ pdfjs-dist@2.1.266:
   dependencies:
     node-ensure "^0.0.0"
     worker-loader "^2.0.0"
+
+pdfjs-dist@2.12.313:
+  version "2.12.313"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.12.313.tgz#62f2273737bb956267ae2e02cdfaddcb1099819c"
+  integrity sha512-1x6iXO4Qnv6Eb+YFdN5JdUzt4pAkxSp3aLAYPX93eQCyg/m7QFzXVWJHJVtoW48CI8HCXju4dSkhQZwoheL5mA==
+
+pdfjs-dist@^2.16.105:
+  version "2.16.105"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.16.105.tgz#937b9c4a918f03f3979c88209d84c1ce90122c2a"
+  integrity sha512-J4dn41spsAwUxCpEoVf6GVoz908IAA3mYiLmNxg8J9kfRXc2jxpbUepcP0ocp0alVNLFthTAM8DZ1RaHh8sU0A==
+  dependencies:
+    dommatrix "^1.0.3"
+    web-streams-polyfill "^3.2.1"
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.2.2"
@@ -7325,6 +7381,22 @@ react-pdf@^4.2.0:
     merge-class-names "^1.1.1"
     pdfjs-dist "2.1.266"
     prop-types "^15.6.2"
+
+react-pdf@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-5.7.2.tgz#c458dedf7983822668b40dcac1eae052c1f6e056"
+  integrity sha512-hdDwvf007V0i2rPCqQVS1fa70CXut17SN3laJYlRHzuqcu8sLLjEoeXihty6c0Ev5g1mw31b8OT8EwRw1s8C4g==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    file-loader "^6.0.0"
+    make-cancellable-promise "^1.0.0"
+    make-event-props "^1.1.0"
+    merge-class-names "^1.1.1"
+    merge-refs "^1.0.0"
+    pdfjs-dist "2.12.313"
+    prop-types "^15.6.2"
+    tiny-invariant "^1.0.0"
+    tiny-warning "^1.0.0"
 
 react-refresh@0.8.3:
   version "0.8.3"
@@ -7779,6 +7851,15 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+schema-utils@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
+  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
+  dependencies:
+    "@types/json-schema" "^7.0.8"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
 
 select@^1.1.2:
   version "1.1.2"
@@ -8445,10 +8526,20 @@ tiny-emitter@^2.0.0:
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
+tiny-invariant@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
+  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
+
 tiny-invariant@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 tinycolor2@1.4.2:
   version "1.4.2"
@@ -8794,6 +8885,11 @@ watchpack@^1.7.4:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
+
+web-streams-polyfill@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 web-vitals@0.2.4:
   version "0.2.4"


### PR DESCRIPTION
Before merge:
* [x] add actual tips and tricks to `ResumeReviewGuide`
* [x] fix email template (this is in advisors-gql but it throws a server side error after the upload, due to what I'm pretty sure is an error in the template for it)
* [ ] if it isn't a ton of effort, make the annotation author be set to the actual author of the annotation, right now it's hardcoded to an empty string so it doesn't look weird but it would be nice to pull it from profile. see ResumeReview.js:124
* [ ] not a huge deal but there's a weird hack to make the annotation icon show up, which results in it making a faulty request to `/respond/[token]/[requestid]/annotation-note.svg` - it doesn't break anything but a way to prevent it from making this request would be nice (we could just hardcode this in getserversideprops i think) 